### PR TITLE
Adds entry preview generation to the Markdown parser

### DIFF
--- a/lambda-blog/src/lambda_blog/parsers/md.clj
+++ b/lambda-blog/src/lambda_blog/parsers/md.clj
@@ -3,7 +3,7 @@
   (:refer-clojure :exclude [read-string])
   (:require [clojure.edn :refer [read-string]]
             [clojure.stacktrace :refer [print-stack-trace]]
-            [clojure.string :refer [split]]
+            [clojure.string :refer [replace-first split]]
             [lambda-blog.utils :refer [substitute]]
             [markdown.core :refer [md-to-html-string md-to-html-string-with-meta]]
             [taoensso.timbre :as log]))
@@ -63,14 +63,16 @@ Vector: [some more values]
                           :heading-anchors heading-anchors
                           :reference-links? reference-links?])
           preview-separator #"(?i)<!--\s*more\s*-->"
-          preview (when (and previews?
-                             (re-find preview-separator contents))
+          preview (when (and previews? (re-find preview-separator contents))
                     (-> contents
                         (split preview-separator)
                         first
                         p
                         :html))
-          {:keys [html metadata]} (p contents)]
+          {:keys [html metadata]} (-> contents
+                                      (replace-first preview-separator
+                                                     "<a name=\"preview-more\"></a>")
+                                      p)]
       (conj {:metadata (parse-metadata metadata)
              :contents html}
             (when preview

--- a/lambda-blog/src/lambda_blog/templates/entries.clj
+++ b/lambda-blog/src/lambda_blog/templates/entries.clj
@@ -68,7 +68,8 @@
        (entry-tags entry)))))
    (if preview
      [preview
-      (a {:href (pathcat path-to-root path)}
+      ;; NOTE #preview-more should be added by the parser.
+      (a {:href (pathcat path-to-root (str path "#preview-more"))}
          "Continue reading "
          (i {:class [:fa :fa-chevron-right]}))]
      contents)))

--- a/lambda-blog/test/lambda_blog/md_parser_test.clj
+++ b/lambda-blog/test/lambda_blog/md_parser_test.clj
@@ -107,7 +107,7 @@
                  :preview))
   (is (= (parse with-preview)
          {:metadata {}
-          :contents "<h1>Test</h1>stuff<!&ndash; more &ndash;>stuff" ;; FIXME Should be a comment.
+          :contents "<h1>Test</h1>stuff<a name=\"preview-more\"></a>stuff"
           :preview "<h1>Test</h1>stuff"}))
   (is (contains? (parse with-pokemon-preview)
                  :preview)))


### PR DESCRIPTION
Closes #89 

For now, just a simple regex split on the first occurrence of `<!-- more -->` in the entry contents with no regard for any higher level structure.
